### PR TITLE
Fix: multiarch build by downloading the right golang binary

### DIFF
--- a/cmd/Dockerfile
+++ b/cmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream9 as builder
+FROM quay.io/centos/centos:stream9 AS builder
 
 RUN mkdir /workdir
 WORKDIR /workdir
@@ -7,10 +7,16 @@ COPY go.mod .
 
 RUN dnf install -y wget
 
+# these variable are automatically set during the multiarch build by docker buildx
+ARG TARGETOS
+ARG TARGETARCH
+ENV TARGETOS=${TARGETOS:-linux}
+ENV TARGETARCH=${TARGETARCH:-amd64}
+
 RUN GO_VERSION=$(sed -En 's/^go +(.*)$/\1/p' go.mod) && \
-    wget https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz && \
-    tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz && \
-    rm go${GO_VERSION}.linux-amd64.tar.gz
+    wget https://dl.google.com/go/go${GO_VERSION}.${TARGETOS}-${TARGETARCH}.tar.gz && \
+    tar -C /usr/local -xzf go${GO_VERSION}.${TARGETOS}-${TARGETARCH}.tar.gz && \
+    rm go${GO_VERSION}.${TARGETOS}-${TARGETARCH}.tar.gz
 
 ENV PATH /usr/local/go/bin:$PATH
 


### PR DESCRIPTION
Use TARGETOS and TARGETARCH build args in Dockerfile to determine the right golang binary.

This is required to fix multiarch build with GitHub actions.

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature or fix, just one!
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what did you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering to future generations.
-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
