### PR TITLE
Fix: multiarch build by using crosscompilation

### DIFF
--- a/.github/workflows/image-build-test.yaml
+++ b/.github/workflows/image-build-test.yaml
@@ -27,9 +27,5 @@ jobs:
         with:
           context: .
           push: false
-          # no need to explicitly set goarch, 
-          # correct arch will be selected for each build platform 
-          build-args: |
-            goarch=
           platforms: ${{ env.BUILD_PLATFORMS }}
           file: ./cmd/Dockerfile

--- a/.github/workflows/image-push-main.yaml
+++ b/.github/workflows/image-push-main.yaml
@@ -45,10 +45,6 @@ jobs:
         with:
           context: .
           push: true
-          # no need to explicitly set goarch, 
-          # correct arch will be selected for each build platform 
-          build-args: |
-            goarch=
           platforms: ${{ env.BUILD_PLATFORMS }}
           tags: |
             ${{ env.IMAGE_NAME }}:latest

--- a/.github/workflows/image-push-release.yaml
+++ b/.github/workflows/image-push-release.yaml
@@ -47,10 +47,6 @@ jobs:
         with:
           context: .
           push: true
-          # no need to explicitly set goarch, 
-          # correct arch will be selected for each build platform 
-          build-args: |
-            goarch=
           platforms: ${{ env.BUILD_PLATFORMS }}
           tags: |
             ${{ steps.docker_meta.outputs.tags }}

--- a/cmd/Dockerfile
+++ b/cmd/Dockerfile
@@ -1,27 +1,42 @@
-FROM quay.io/centos/centos:stream9 as builder
+FROM --platform=$BUILDPLATFORM quay.io/centos/centos:stream9 AS builder
 
 RUN mkdir /workdir
-WORKDIR /workdir
+# Support overriding target GOARCH during `make docker-build`
+ARG goarch=
 
-COPY go.mod .
+# these variable are automatically set during the multiarch build by docker buildx
+ARG TARGETOS
+ARG TARGETARCH
+ENV TARGETOS=${TARGETOS:-linux}
+ENV TARGETARCH=${TARGETARCH:-amd64}
+
+ARG BUILDOS
+ARG BUILDARCH
+ENV BUILDOS=${BUILDOS:-linux}
+ENV BUILDARCH=${BUILDARCH:-amd64}
+
+ENV GOOS=${TARGETOS}
+ENV GOARCH=${goarch:-$TARGETARCH}
+ENV CGO_ENABLED=0
+ENV GOFLAGS=-mod=vendor
+
+WORKDIR /workdir
 
 RUN dnf install -y wget
 
-RUN GO_VERSION=$(sed -En 's/^go +(.*)$/\1/p' go.mod) && \
-    wget https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz && \
-    tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz && \
-    rm go${GO_VERSION}.linux-amd64.tar.gz
+COPY go.mod .
+COPY go.sum .
 
-ENV PATH /usr/local/go/bin:$PATH
+RUN GO_VERSION=$(sed -En 's/^go +(.*)$/\1/p' go.mod) && \
+    wget https://dl.google.com/go/go${GO_VERSION}.${BUILDOS}-${BUILDARCH}.tar.gz && \
+    tar -C /usr/local -xzf go${GO_VERSION}.${BUILDOS}-${BUILDARCH}.tar.gz && \
+    rm go${GO_VERSION}.${BUILDOS}-${BUILDARCH}.tar.gz
+
+ENV PATH=/usr/local/go/bin:$PATH
+
+RUN go mod download
 
 COPY . .
-
-ENV GOOS linux
-# Support overriding target GOARCH during `make docker-build`
-ARG goarch=amd64
-ENV GOARCH=$goarch
-ENV CGO_ENABLED 0
-ENV GOFLAGS -mod=vendor
 
 RUN mkdir /workdir/bin
 RUN go build -tags no_openssl -o /workdir/bin/ovs ./cmd/plugin
@@ -30,6 +45,8 @@ RUN go build -tags no_openssl -o /workdir/bin/ovs-mirror-producer ./cmd/mirror-p
 RUN go build -tags no_openssl -o /workdir/bin/ovs-mirror-consumer ./cmd/mirror-consumer
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal
+
 RUN microdnf install -y findutils
+
 COPY --from=builder /workdir/.version /.version
 COPY --from=builder /workdir/bin/* /


### PR DESCRIPTION
Use quay.io/centos/centos:stream9 with the –platform=$BUILDPLATFORM flag, in this case the image is pulled for the builder host's current architecture. The BUILDOS and BUILDARCH args are used to download the right go binary for the build platform.
Cross-compilation occurs in the builder image using TARGETOS and TARGETARCH build arguments to determine the target OS/arch. These args are set automatically by the multiarch-build process (with docker buildx). The final container image (registry.access.redhat.com/ubi9/ubi-minimal) is pulled for the correct target architecture, such as amd64 or arm64.

This update fixes support for multiarch builds and speeds up image building, as cross-compilation is faster than compiling on a non-native platform.

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature or fix, just one!
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what did you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering to future generations.
-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
